### PR TITLE
Handle output_directory and change_directory properly

### DIFF
--- a/src/cluttex.lua
+++ b/src/cluttex.lua
@@ -180,7 +180,7 @@ end
 
 -- handle change_directory properly (needs to be after initscript gen)
 if options.change_directory then
-	tex_options.output_directory = nil
+  tex_options.output_directory = nil
 end
 
 -- Run TeX command (*tex, *latex)

--- a/src/cluttex.lua
+++ b/src/cluttex.lua
@@ -123,9 +123,11 @@ end
 local original_wd = filesys.currentdir()
 if options.change_directory then
   local TEXINPUTS = os.getenv("TEXINPUTS") or ""
-  filesys.chdir(options.output_directory)
+  assert(filesys.chdir(options.output_directory))
   options.output = pathutil.abspath(options.output, original_wd)
   os.setenv("TEXINPUTS", original_wd .. pathsep .. TEXINPUTS)
+  -- after changing the pwd, '.' is always the output_directory (needed for some path generation)
+  options.output_directory = "."
 end
 if options.bibtex or options.biber then
   local BIBINPUTS = os.getenv("BIBINPUTS") or ""
@@ -174,6 +176,11 @@ if engine.is_luatex then
   local initscriptfile = path_in_output_directory("cluttexinit.lua")
   luatexinit.create_initialization_script(initscriptfile, tex_options)
   tex_options.lua_initialization_script = initscriptfile
+end
+
+-- handle change_directory properly (needs to be after initscript gen)
+if options.change_directory then
+	tex_options.output_directory = nil
 end
 
 -- Run TeX command (*tex, *latex)


### PR DESCRIPTION
If option change_directory is used output_directory should be relative
to the new pwd (in current implementation that would be `.` always) or
use absolute path. In addition if option change_directory is used flag
`-output-directory` doesn't need to be set on the tex compilation
command.

This implements this behaviour by setting `options.output_directory` to
`nil` (so that `-output-directory` will not be set later) after
generating the init lua script.

Addresses #7 

I'm not quite sure about the `options.output_directory` handling. Maybe it would be nicer if `tex_engine` would respect the `change_directory` option to achieve a more consistent `tex_options`. On the other hand having a `change_directory` option for `tex_engine` just to avoid setting the `-output-directory` flag on the tex command isn't that nice either.

I hope these are all spots which were causing the `change_directory` trouble.