### PR TITLE
Make --watch an option to select the watch engine

### DIFF
--- a/src/cluttex.lua
+++ b/src/cluttex.lua
@@ -571,7 +571,7 @@ if options.watch then
       watcher:close()
       return true
     end
-  elseif shellutil.has_command("fswatch") then
+  elseif shellutil.has_command("fswatch") and (options.watch == "auto" or options.watch == "fswatch")  then
     if CLUTTEX_VERBOSITY >= 2 then
       message.info("Using `fswatch' command")
     end
@@ -595,7 +595,7 @@ if options.watch then
       end
       return false
     end
-  elseif shellutil.has_command("inotifywait") then
+  elseif shellutil.has_command("inotifywait") and (options.watch == "auto" or options.watch == "inotifywait") then
     if CLUTTEX_VERBOSITY >= 2 then
       message.info("Using `inotifywait' command")
     end
@@ -620,7 +620,13 @@ if options.watch then
       return false
     end
   else
-    message.error("Could not watch files because neither `fswatch' nor `inotifywait' was installed.")
+    if options.watch == "auto" then
+      message.error("Could not watch files because neither `fswatch' nor `inotifywait' was installed.")
+    elseif options.watch == "fswatch" then
+      message.error("Could not watch files because your selected engine `fswatch' was not installed.")
+    elseif options.watch == "inotifywait" then
+      message.error("Could not watch files because your selected engine `inotifywait' was not installed.")
+    end
     message.info("See ClutTeX's manual for details.")
     os.exit(1)
   end

--- a/src/texrunner/handleoption.lua
+++ b/src/texrunner/handleoption.lua
@@ -475,9 +475,11 @@ local function handle_cluttex_options(arg)
 
   -- parameter validy check TODO should this be organized as function like
   -- set_default_values and with a key in the option spec (list or function)?
-  if options.watch ~= "fswatch" and options.watch ~= "inotifywait" then
-    message.error("Unknown wait engine '", options.watch, "'.")
-    os.exit(1)
+  if options.watch then
+	  if options.watch ~= "fswatch" and options.watch ~= "inotifywait" then
+		message.error("Unknown wait engine '", options.watch, "'.")
+		os.exit(1)
+	  end
   end
 
   if options.output_format == "pdf" then

--- a/src/texrunner/handleoption.lua
+++ b/src/texrunner/handleoption.lua
@@ -47,8 +47,9 @@ Options:
                                  cross-references.  [default: 3]
       --start-with-draft       Start with draft mode.
       --[no-]change-directory  Change directory before running TeX.
-      --watch                  Watch input files for change.  Requires fswatch
-                                 program to be installed.
+      --watch[=ENGINE]         Watch input files for change.  Requires fswatch
+                                 or inotifywait to be installed. ENGINE is one of
+                                 `fswatch', `inotifywait' or `auto' [default: `auto']
       --tex-option=OPTION      Pass OPTION to TeX as a single option.
       --tex-options=OPTIONs    Pass OPTIONs to TeX as multiple options.
       --dvipdfmx-option[s]=OPTION[s]  Same for dvipdfmx.
@@ -122,6 +123,8 @@ local option_spec = {
   },
   {
     long = "watch",
+    param = true,
+    default = "auto",
   },
   {
     short = "h",
@@ -312,7 +315,7 @@ local function handle_cluttex_options(arg)
 
     elseif name == "watch" then
       assert(options.watch == nil, "multiple --watch options")
-      options.watch = true
+      options.watch = param
 
     elseif name == "help" then
       usage(arg)
@@ -469,6 +472,13 @@ local function handle_cluttex_options(arg)
   end
 
   set_default_values(options)
+
+  -- parameter validy check TODO should this be organized as function like
+  -- set_default_values and with a key in the option spec (list or function)?
+  if options.watch ~= "fswatch" and options.watch ~= "inotifywait" then
+    message.error("Unknown wait engine '", options.watch, "'.")
+    os.exit(1)
+  end
 
   if options.output_format == "pdf" then
     if options.check_driver ~= nil then


### PR DESCRIPTION
Background behind this is that for some reason `fswatch` doesn't work for me (strangely only in some directories, might be a problem with symlinks or so, but I didn't found out yet).

Thus I wanted to use `inotifywait` which isn't possible with the current wait engine check (if `fswatch` is installed it always is preferred over `inotifywait`).

Please check if I used your commandline options library correctly, because I'm not sure of this. And in addition I wonder if there is a way to perform some parameter validity check with your library (I didn't found one)?

---
If there is no such feature, I'd propose to add a new key to the `option_spec` table entries (e.g. `valid_check`) which could be a table with the allowed values or a function to manually check for validity. Then somewhere I now have placed the validity check for the watch option there could be a function `check_paramters` which then performs the validity check (after the color etc has been set for nice error messages).

In case you also think it would be worth to do so, further discussion/work should be in a new issue/pull request