### PR TITLE
Change LUAINPUTS env var to find lua files on dir change

### DIFF
--- a/src/cluttex.lua
+++ b/src/cluttex.lua
@@ -123,9 +123,11 @@ end
 local original_wd = filesys.currentdir()
 if options.change_directory then
   local TEXINPUTS = os.getenv("TEXINPUTS") or ""
+  local LUAINPUTS = os.getenv("LUAINPUTS") or ""
   assert(filesys.chdir(options.output_directory))
   options.output = pathutil.abspath(options.output, original_wd)
   os.setenv("TEXINPUTS", original_wd .. pathsep .. TEXINPUTS)
+  os.setenv("LUAINPUTS", original_wd .. pathsep .. LUAINPUTS)
   -- after changing the pwd, '.' is always the output_directory (needed for some path generation)
   options.output_directory = "."
 end


### PR DESCRIPTION
When changing directory, we already modify `TEXINPUTS` so that `.tex`
files are found from the original directory.
Since this doesn't work for `.lua` files we have to adjust another
environment variable as well, `LUAINPUTS`.
This is what this PR is for.

For Reference on the environment variables see `kpsewhich --help-formats`