### PR TITLE
Add --glossaries option

### DIFF
--- a/src/cluttex.lua
+++ b/src/cluttex.lua
@@ -381,7 +381,7 @@ local function single_run(auxstatus, iteration)
           -- Run xindy/makeindex if the specified input-file is new or updated
           local inputfileinfo = {path = file.path, abspath = file.abspath, kind = "auxiliary"}
           local outputfile = cfg.out
-          if reruncheck.comparefileinfo({inputfileinfo}, auxstatus) or reruncheck.comparefiletime(file.abspath, outputfile, auxstatus) then
+          if reruncheck.comparefileinfo({inputfileinfo}, auxstatus) or reruncheck.comparefiletime(file.abspath, cfg.inp, auxstatus) then
             coroutine.yield(cfg.cmd)
             table.insert(filelist, {path = outputfile, abspath = outputfile, kind = "auxiliary"})
           else

--- a/src/cluttex.lua
+++ b/src/cluttex.lua
@@ -384,11 +384,11 @@ local function single_run(auxstatus, iteration)
           if reruncheck.comparefileinfo({inputfileinfo}, auxstatus) or reruncheck.comparefiletime(file.abspath, cfg.inp, auxstatus) then
             coroutine.yield(cfg.cmd)
             table.insert(filelist, {path = outputfile, abspath = outputfile, kind = "auxiliary"})
-          -- else TODO why is this here in the other "modules"? Here it only works without this one
-          --   local succ, err = filesys.touch(outputfile)
-          --   if not succ then
-          --     message.warn("Failed to touch " .. outputfile .. " (" .. err .. ")")
-          --   end
+          else
+            local succ, err = filesys.touch(outputfile)
+            if not succ then
+              message.warn("Failed to touch " .. outputfile .. " (" .. err .. ")")
+            end
           end
         end
       end

--- a/src/cluttex.lua
+++ b/src/cluttex.lua
@@ -384,11 +384,11 @@ local function single_run(auxstatus, iteration)
           if reruncheck.comparefileinfo({inputfileinfo}, auxstatus) or reruncheck.comparefiletime(file.abspath, cfg.inp, auxstatus) then
             coroutine.yield(cfg.cmd)
             table.insert(filelist, {path = outputfile, abspath = outputfile, kind = "auxiliary"})
-          else
-            local succ, err = filesys.touch(outputfile)
-            if not succ then
-              message.warn("Failed to touch " .. output_ind .. " (" .. err .. ")")
-            end
+          -- else TODO why is this here in the other "modules"? Here it only works without this one
+          --   local succ, err = filesys.touch(outputfile)
+          --   if not succ then
+          --     message.warn("Failed to touch " .. outputfile .. " (" .. err .. ")")
+          --   end
           end
         end
       end

--- a/src/texrunner/handleoption.lua
+++ b/src/texrunner/handleoption.lua
@@ -77,11 +77,13 @@ local function parse_glossaries_option(opt)
     ret.path = ret.type
   end
 
+  ret.ist = pathutil.replaceext(ret.log, "ist")
+
   if #s >= 6 then
     ret.args = s[6]
   else
     if ret.type == "makeindex" then
-      ret.args = ("-t %s -o %s %s"):format(shellutil.escape(ret.log), shellutil.escape(ret.out), shellutil.escape(ret.inp))
+      ret.args = ("-s %s -t %s -o %s %s"):format(shellutil.escape(ret.ist), shellutil.escape(ret.log), shellutil.escape(ret.out), shellutil.escape(ret.inp))
     elseif ret.type == "xindy" then
       ret.args = ("-t %s -o %s %s"):format(shellutil.escape(ret.log), shellutil.escape(ret.out), shellutil.escape(ret.inp))
     else

--- a/src/texrunner/handleoption.lua
+++ b/src/texrunner/handleoption.lua
@@ -513,6 +513,7 @@ local function handle_cluttex_options(arg)
       table.insert(options.dvipdfmx_extraoptions, param)
 
     elseif name == "makeindex" then
+      assert(not options.glossaries, "'makeindex' cannot be used together with 'glossaries'")
       assert(options.makeindex == nil, "multiple --makeindex options")
       options.makeindex = param
 
@@ -527,10 +528,13 @@ local function handle_cluttex_options(arg)
       options.biber = param
 
     elseif name == "makeglossaries" then
+      assert(not options.glossaries, "'makeglossaries' cannot be used together with 'glossaries'")
       assert(options.makeglossaries == nil, "multiple --makeglossaries options")
       options.makeglossaries = param
 
     elseif name == "glossaries" then
+      assert(not options.makeglossaries, "'glossaries' cannot be used together with 'makeglossaries'")
+      assert(not options.makeindex, "'glossaries' cannot be used together with 'makeindex'")
       if not options.glossaries then
         options.glossaries = {}
       end

--- a/src/texrunner/handleoption.lua
+++ b/src/texrunner/handleoption.lua
@@ -57,18 +57,18 @@ local function parse_glossaries_option(opt)
     return nil, "Invalid glossaries parameter. \""..ret.type.."\" is unsupported"
   end
 
-  ret.log = s[2]
+  ret.out = s[2]
 
   if #s >= 3 and s[3] ~= "" then
-    ret.out = s[3]
+    ret.inp = s[3]
   else
-    ret.out = ret.log:sub(1,-2).."s"
+    ret.inp = ret.out:sub(1,-2).."o"
   end
 
   if #s >= 4 and s[4] ~= "" then
-    ret.inp = s[4]
+    ret.log = s[4]
   else
-    ret.inp = ret.log:sub(1,-2).."o"
+    ret.log = ret.out:sub(1,-2).."g"
   end
 
   if #s >= 5 and s[5] ~= "" then
@@ -135,21 +135,21 @@ Options:
       --biber[=COMMAND+OPTIONs]    Command for Biber.
       --makeglossaries[=COMMAND+OPTIONs]  Command for makeglossaries.
       --glossaries=[CONFIGURATION]  Configuration can contain
-                                    "type:logFile:outputFile:inputFile:pathToCommand:commandArgs" (":" can be escaped with "\").
-                                    Only the logFile and either type or pathToCommand
+                                    "type:outputFile:inputFile:logFile:pathToCommand:commandArgs" (":" can be escaped with "\").
+                                    Only the outputFile and either type or pathToCommand
                                     are required, the other options will be infered
-                                    automatically (does not work always for outputFile and
-                                    inputFile). If commandArgs is being specified,
+                                    automatically (does not work always for inputFile and
+                                    logFile). If commandArgs is being specified,
                                     these will be the only arguments passed to the
                                     command. If type is unspecified commandArgs must be
                                     specified. As types we support makeindex and xindy.
                                     Specify this option multiple times to register multiple
                                     glossaries. The default value works for a
-                                    configuration with the usual glossary (glg,glo,gls)
+                                    configuration with the usual glossary (glo,gls,glg)
                                     with a tex-file named "main.tex".
                                     A typical example is
-                                    "makeindex:main.alg:main.acr:main.acn" or
-                                    "makeindex:main.glg:main.glo:main.gls" (default)
+                                    "makeindex:main.acr:main.acn:main.alg" or
+                                    "makeindex:main.glo:main.gls:main.glg" (default)
   -h, --help                   Print this message and exit.
   -v, --version                Print version information and exit.
   -V, --verbose                Be more verbose.
@@ -341,7 +341,7 @@ local option_spec = {
   {
     long = "glossaries",
     param = true,
-    default = "makeindex:main.glg:main.glo:main.gls",
+    default = "makeindex:main.glo:main.gls:main.glg",
   },
 }
 
@@ -513,7 +513,7 @@ local function handle_cluttex_options(arg)
       table.insert(options.dvipdfmx_extraoptions, param)
 
     elseif name == "makeindex" then
-      assert(not options.glossaries, "'makeindex' cannot be used together with 'glossaries'")
+      assert(not options.glossaries, "'makeindex' cannot be used together with 'glossaries'\nUse e.g. --glossaries='makeindex:main.ind:main.idx:main.ilg' instead of makeindex")
       assert(options.makeindex == nil, "multiple --makeindex options")
       options.makeindex = param
 
@@ -528,13 +528,13 @@ local function handle_cluttex_options(arg)
       options.biber = param
 
     elseif name == "makeglossaries" then
-      assert(not options.glossaries, "'makeglossaries' cannot be used together with 'glossaries'")
+      assert(not options.glossaries, "'makeglossaries' cannot be used together with 'glossaries'\nUse e.g. --glossaries='makeindex:main.glo:main.gls:main.glg' instead of makeglossaries")
       assert(options.makeglossaries == nil, "multiple --makeglossaries options")
       options.makeglossaries = param
 
     elseif name == "glossaries" then
-      assert(not options.makeglossaries, "'glossaries' cannot be used together with 'makeglossaries'")
-      assert(not options.makeindex, "'glossaries' cannot be used together with 'makeindex'")
+      assert(not options.makeglossaries, "'glossaries' cannot be used together with 'makeglossaries'\nUse e.g. --glossaries='makeindex:main.glo:main.gls:main.glg' instead of makeglossaries")
+      assert(not options.makeindex, "'glossaries' cannot be used together with 'makeindex'\nUse e.g. --glossaries='makeindex:main.ind:main.idx:main.ilg' instead of makeindex")
       if not options.glossaries then
         options.glossaries = {}
       end

--- a/src/texrunner/reruncheck.lua
+++ b/src/texrunner/reruncheck.lua
@@ -81,6 +81,12 @@ local function parse_recorder_file(file, options, filelist, filemap)
           -- Treat .idx files (to be processed by MakeIndex) as auxiliary
           kind = "auxiliary"
           -- ...and .ind files
+        elseif options.glossaries then
+          for _,i in ipairs(options.glossaries) do
+            if pathutil.basename(abspath) == i.inp then
+              kind = "auxiliary"
+            end
+          end
         elseif ext == "bcf" then -- biber
           kind = "auxiliary"
         elseif ext == "glo" then -- makeglossaries

--- a/src/texrunner/reruncheck.lua
+++ b/src/texrunner/reruncheck.lua
@@ -52,6 +52,13 @@ local function parse_recorder_file(file, options, filelist, filemap)
           if ext == "bbl" then
             kind = "auxiliary"
           end
+          if options.glossaries then
+            for _,i in ipairs(options.glossaries) do
+              if pathutil.basename(abspath) == i.out then
+                kind = "auxiliary"
+              end
+            end
+          end
           fileinfo = {path = path, abspath = abspath, kind = kind}
           table.insert(filelist, fileinfo)
           filemap[abspath] = fileinfo


### PR DESCRIPTION
Reason why I added this option is that the `glossaries` package offers the ability to add many different glossaries (not just the usual `glo` but also e.g. something for symbols or abbreviations). While `makeglossaries` is able to process these other glossaries, `cluttex` has no chance of detecting changes in files different than `.glo` as it doesn't know which files to watch.

Thus, `--glossaries` offers the ability to register a tool (`makeindex`/`xindy`, these are the tools used by `makeglossaries` internally anyhow) with the respective files (needs to specify the whole filename+ext as I wanted to give full flexibility, most of the time the filename will be `main` or `master` I think) to watch.

See https://github.com/minoki/cluttex/issues/14 for some ideas and discussion (with myself).

I changed a bit the order of the arguments in the options string so now it is `type:out:inp:log:path:args` and `inp` and `log` are inferred from `out` (seems like a more logical ordering). I chose `out` before `inp` as the file-ending of `out` is typically better known than the one of `inp` and I wanted the parameter which can be used to infer the other ones as early as possible.

---
This option offers the `--makeindex` as well as the `--makeglossaries` (I don't know of `makeglossaries` flags/options that can not be set directly for `makeindex`/`xindy`) features. The only thing we can't do properly is to check for `No file ...` and issue a warning that the user shall set a respective option (the only thing I could think of is to watch for common extensions like `ind` (index), `sls` (symbols), `nls` (numbers), `gls` (glossaries) and `acr` (acronyms/abbreviations)).

So I personally would deprecate these functions or redirect them to the proper `--glossaries` call, but that's not my decision as collaborator. That's a decision of @minoki as maintainer, I think.